### PR TITLE
Fix eslint 12.2.3 issues and drop react-intl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16826,6 +16826,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -17300,12 +17301,14 @@
     "intl-format-cache": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.2.9.tgz",
-      "integrity": "sha512-Zv/u8wRpekckv0cLkwpVdABYST4hZNTDaX7reFetrYTJwxExR2VyTqQm+l0WmL0Qo8Mjb9Tf33qnfj0T7pjxdQ=="
+      "integrity": "sha512-Zv/u8wRpekckv0cLkwpVdABYST4hZNTDaX7reFetrYTJwxExR2VyTqQm+l0WmL0Qo8Mjb9Tf33qnfj0T7pjxdQ==",
+      "dev": true
     },
     "intl-messageformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
       "integrity": "sha512-I+tSvHnXqJYjDfNmY95tpFMj30yoakC6OXAo+wu/wTMy6tA/4Fd4mvV7Uzs4cqK/Ap29sHhwjcY+78a8eifcXw==",
+      "dev": true,
       "requires": {
         "intl-messageformat-parser": "1.4.0"
       }
@@ -17313,12 +17316,14 @@
     "intl-messageformat-parser": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
-      "integrity": "sha512-/XkqFHKezO6UcF4Av2/Lzfrez18R0jyw7kRFhSeB/YRakdrgSc9QfFZUwNJI9swMwMoNPygK1ArC5wdFSjPw+A=="
+      "integrity": "sha512-/XkqFHKezO6UcF4Av2/Lzfrez18R0jyw7kRFhSeB/YRakdrgSc9QfFZUwNJI9swMwMoNPygK1ArC5wdFSjPw+A==",
+      "dev": true
     },
     "intl-relativeformat": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.2.0.tgz",
       "integrity": "sha512-4bV/7kSKaPEmu6ArxXf9xjv1ny74Zkwuey8Pm01NH4zggPP7JHwg2STk8Y3JdspCKRDriwIyLRfEXnj2ZLr4Bw==",
+      "dev": true,
       "requires": {
         "intl-messageformat": "^2.0.0"
       }
@@ -17338,6 +17343,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -19657,7 +19663,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -20303,6 +20310,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -27965,6 +27973,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
       "integrity": "sha512-27jnDlb/d2A7mSJwrbOBnUgD+rPep+abmoJE511Tf8BnoONIAUehy/U1zZCHGO17mnOwMWxqN4qC0nW11cD6rA==",
+      "dev": true,
       "requires": {
         "hoist-non-react-statics": "^3.3.0",
         "intl-format-cache": "^2.0.5",
@@ -27976,7 +27985,8 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "peerDependencies": {
     "@theforeman/vendor": ">= 6.0.0"
   },
-  "dependencies": {
-    "react-intl": "^2.8.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",

--- a/webpack/helper.js
+++ b/webpack/helper.js
@@ -49,24 +49,22 @@ const areReactElementsEqual = (element1, element2) => {
 
 /**
  * Recursively copies values from the source hash (`src`) to the destination hash (`dest`).
+ * Only keys that are a member of dest will copied from src.
  *
  * @param {Object} dest - The destination hash to copy values into.
  * @param {Object} src - The source hash from which values are copied.
  * @returns {void} - The function modifies the destination hash in place.
  */
 function deepCopy(dest, src) {
-  // eslint-disable-next-line no-unused-vars
-  for (const key in dest) {
-    if (dest.hasOwnProperty(key)) {
-      if (src.hasOwnProperty(key)) {
-        if (typeof dest[key] === 'object' && typeof src[key] === 'object') {
-          deepCopy(dest[key], src[key]);
-        } else if (dest[key] !== src[key]) {
-          dest[key] = src[key];
-        }
+  Object.keys(dest).forEach(key => {
+    if (src.hasOwnProperty(key)) {
+      if (typeof dest[key] === 'object' && typeof src[key] === 'object') {
+        deepCopy(dest[key], src[key]);
+      } else if (dest[key] !== src[key]) {
+        dest[key] = src[key];
       }
     }
-  }
+  });
 }
 
 /**


### PR DESCRIPTION
* Fix JS iteration suggested by eslint
* Drop `react-intl` dependency as it is included in `@theforeman/foreman-vendor`