### PR TITLE
Fix import of dispatchAPICallbackToast helper

### DIFF
--- a/webpack/api_helper.js
+++ b/webpack/api_helper.js
@@ -68,19 +68,17 @@ const apiUpdateResourceQuota = (
 
 /**
  * Handles the callback response from an asynchronous operation, displaying a toast message accordingly.
- * @param {function} dispatcher - The dispatcher function to dispatch actions.
  * @param {boolean} isSuccess - Indicates whether the operation was successful or not.
  * @param {object} response - The response object returned from the operation.
  * @param {string} successMessage - The success message to display in case of success.
  * @param {string} errorMessage - The error message to display in case of failure.
  */
 const dispatchAPICallbackToast = (
-  dispatch,
   isSuccess,
   response,
   successMessage,
   errorMessage
-) => {
+) => dispatch => {
   if (isSuccess) {
     dispatch(
       addToast({

--- a/webpack/api_helper.test.js
+++ b/webpack/api_helper.test.js
@@ -21,13 +21,13 @@ describe('dispatchAPICallbackToast', () => {
     const successMessage = 'Success message';
     const errorMessage = 'Error message';
 
-    dispatchAPICallbackToast(
-      dispatch,
+    const dispatcher = dispatchAPICallbackToast(
       isSuccess,
       response,
       successMessage,
       errorMessage
     );
+    dispatcher(dispatch);
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith({
@@ -50,13 +50,13 @@ describe('dispatchAPICallbackToast', () => {
     const successMessage = 'Success message';
     const errorMessage = 'Error message';
 
-    dispatchAPICallbackToast(
-      dispatch,
+    const dispatcher = dispatchAPICallbackToast(
       isSuccess,
       response,
       successMessage,
       errorMessage
     );
+    dispatcher(dispatch);
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith({
@@ -79,13 +79,13 @@ describe('dispatchAPICallbackToast', () => {
     const successMessage = 'Success message';
     const errorMessage = 'Error message';
 
-    dispatchAPICallbackToast(
-      dispatch,
+    const dispatcher = dispatchAPICallbackToast(
       isSuccess,
       response,
       successMessage,
       errorMessage
     );
+    dispatcher(dispatch);
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith({

--- a/webpack/components/ResourceQuotaForm/components/Properties/TextInputField.js
+++ b/webpack/components/ResourceQuotaForm/components/Properties/TextInputField.js
@@ -6,7 +6,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import ActionableDetail from '../../../../lib/ActionableDetail';
 import StaticDetail from './StaticDetail';
-import dispatchAPICallbackToast from '../../../../api_helper';
+import { dispatchAPICallbackToast } from '../../../../api_helper';
 
 const TextInputField = ({
   initialValue,
@@ -36,12 +36,13 @@ const TextInputField = ({
 
   const callback = (success, response) => {
     setIsLoading(false);
-    dispatchAPICallbackToast(
-      dispatch,
-      success,
-      response,
-      `Sucessfully applied ${label}.`,
-      `An error occurred appyling ${label}.`
+    dispatch(
+      dispatchAPICallbackToast(
+        success,
+        response,
+        `Sucessfully applied ${label}.`,
+        `An error occurred appyling ${label}.`
+      )
     );
   };
 

--- a/webpack/components/ResourceQuotaForm/components/Properties/index.js
+++ b/webpack/components/ResourceQuotaForm/components/Properties/index.js
@@ -22,7 +22,7 @@ import ClusterIcon from '@patternfly/react-icons/dist/esm/icons/cluster-icon';
 import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
 
 import { translate as __ } from 'foremanReact/common/I18n';
-import dispatchAPICallbackToast from '../../../../api_helper';
+import { dispatchAPICallbackToast } from '../../../../api_helper';
 
 import './Properties.scss';
 import StatusPropertiesLabel from './StatusPropertiesLabel';
@@ -58,12 +58,13 @@ const Properties = ({
 
   const callbackFetch = (success, response) => {
     setIsFetchLoading(false);
-    dispatchAPICallbackToast(
-      dispatch,
-      success,
-      response,
-      `Sucessfully fetched latest data.`,
-      `An error occurred fetching quota information.`
+    dispatch(
+      dispatchAPICallbackToast(
+        success,
+        response,
+        `Sucessfully fetched latest data.`,
+        `An error occurred fetching quota information.`
+      )
     );
   };
 

--- a/webpack/components/ResourceQuotaForm/components/Resource/index.js
+++ b/webpack/components/ResourceQuotaForm/components/Resource/index.js
@@ -25,7 +25,7 @@ import UnitInputField from './UnitInputField';
 import UtilizationProgress from './UtilizationProgress';
 
 import { resourceAttributesByIdentifier } from '../../ResourceQuotaFormConstants';
-import dispatchAPICallbackToast from '../../../../api_helper';
+import { dispatchAPICallbackToast } from '../../../../api_helper';
 
 // TODO: Visualize maximum resource (tooltip?)
 // TODO: Add error message if given quota limit exceeds present quota utilization (consumed resources)
@@ -70,12 +70,13 @@ const Resource = ({
       setInputValue(response.data[resourceIdentifier]);
       setIsEnabled(response.data[resourceIdentifier] !== null);
     }
-    dispatchAPICallbackToast(
-      dispatch,
-      success,
-      response,
-      `Sucessfully applied ${resourceTitle}.`,
-      `An error occurred appyling ${resourceTitle}.`
+    dispatch(
+      dispatchAPICallbackToast(
+        success,
+        response,
+        `Sucessfully applied ${resourceTitle}.`,
+        `An error occurred appyling ${resourceTitle}.`
+      )
     );
   };
 

--- a/webpack/components/ResourceQuotaForm/components/Submit.js
+++ b/webpack/components/ResourceQuotaForm/components/Submit.js
@@ -5,7 +5,7 @@ import { Button, Flex, FlexItem } from '@patternfly/react-core';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 
-import dispatchAPICallbackToast from '../../../api_helper';
+import { dispatchAPICallbackToast } from '../../../api_helper';
 
 import {
   RESOURCE_IDENTIFIER_ID,
@@ -27,12 +27,13 @@ const Submit = ({ isValid, onCreate, onSubmit }) => {
 
   const onCreateCallback = (success, response) => {
     setIsSubmitLoading(false);
-    dispatchAPICallbackToast(
-      dispatch,
-      success,
-      response,
-      `Sucessfully created new Resource Quota`,
-      `An error occurred while creating new Resource Quota.`
+    dispatch(
+      dispatchAPICallbackToast(
+        success,
+        response,
+        `Sucessfully created new Resource Quota`,
+        `An error occurred while creating new Resource Quota.`
+      )
     );
     if (onSubmit) onSubmit(success);
   };


### PR DESCRIPTION
When importing the dispatchAPICallbackToast helper function, it was not unpacked which resulted in the default module being imported. Finally, this resulted in a TypeError.

The fixed version relates to [foreman:/../notifications.test.js](https://github.com/theforeman/foreman/blob/bf03a259a7e6fd65207b9a40639bb99e0e507dd8/webpack/assets/javascripts/react_app/redux/actions/notifications/notifications.test.js#L11).