### PR TITLE
Fix many to many relation naming

### DIFF
--- a/app/models/concerns/foreman_resource_quota/user_extensions.rb
+++ b/app/models/concerns/foreman_resource_quota/user_extensions.rb
@@ -4,9 +4,9 @@ module ForemanResourceQuota
   module UserExtensions
     extend ActiveSupport::Concern
     included do
-      has_many :resource_quota_users, class_name: 'ForemanResourceQuota::ResourceQuotaUser', dependent: :destroy,
+      has_many :resource_quotas_users, class_name: 'ForemanResourceQuota::ResourceQuotaUser', dependent: :destroy,
         inverse_of: :user
-      has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quota_users
+      has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quotas_users
       attribute :resource_quota_is_optional, :boolean, default: false
 
       scoped_search relation: :resource_quotas, on: :name, complete_value: true, rename: :resource_quota

--- a/app/models/concerns/foreman_resource_quota/usergroup_extensions.rb
+++ b/app/models/concerns/foreman_resource_quota/usergroup_extensions.rb
@@ -4,9 +4,9 @@ module ForemanResourceQuota
   module UsergroupExtensions
     extend ActiveSupport::Concern
     included do
-      has_many :resource_quota_usergroups, class_name: 'ForemanResourceQuota::ResourceQuotaUsergroup',
+      has_many :resource_quotas_usergroups, class_name: 'ForemanResourceQuota::ResourceQuotaUsergroup',
         dependent: :destroy, inverse_of: :usergroup
-      has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quota_usergroups
+      has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quotas_usergroups
 
       scoped_search relation: :resource_quotas, on: :name, complete_value: true, rename: :resource_quota
     end

--- a/app/models/foreman_resource_quota/resource_quota.rb
+++ b/app/models/foreman_resource_quota/resource_quota.rb
@@ -11,11 +11,11 @@ module ForemanResourceQuota
 
     self.table_name = 'resource_quotas'
 
-    has_many :resource_quota_users, class_name: 'ResourceQuotaUser', inverse_of: :resource_quota, dependent: :destroy
-    has_many :users, class_name: '::User', through: :resource_quota_users
-    has_many :resource_quota_usergroups, class_name: 'ResourceQuotaUsergroup', inverse_of: :resource_quota,
+    has_many :resource_quotas_users, class_name: 'ResourceQuotaUser', inverse_of: :resource_quota, dependent: :destroy
+    has_many :users, class_name: '::User', through: :resource_quotas_users
+    has_many :resource_quotas_usergroups, class_name: 'ResourceQuotaUsergroup', inverse_of: :resource_quota,
       dependent: :destroy
-    has_many :usergroups, class_name: '::Usergroup', through: :resource_quota_usergroups
+    has_many :usergroups, class_name: '::Usergroup', through: :resource_quotas_usergroups
     has_many :hosts, class_name: '::Host::Managed', dependent: :nullify
 
     validates :name, presence: true, uniqueness: true

--- a/app/models/foreman_resource_quota/resource_quota_user.rb
+++ b/app/models/foreman_resource_quota/resource_quota_user.rb
@@ -4,7 +4,7 @@ module ForemanResourceQuota
   class ResourceQuotaUser < ApplicationRecord
     self.table_name = 'resource_quotas_users'
 
-    belongs_to :resource_quota, inverse_of: :resource_quota_users
-    belongs_to :user, class_name: '::User', inverse_of: :resource_quota_users
+    belongs_to :resource_quota, inverse_of: :resource_quotas_users
+    belongs_to :user, class_name: '::User', inverse_of: :resource_quotas_users
   end
 end

--- a/app/models/foreman_resource_quota/resource_quota_usergroup.rb
+++ b/app/models/foreman_resource_quota/resource_quota_usergroup.rb
@@ -4,7 +4,7 @@ module ForemanResourceQuota
   class ResourceQuotaUsergroup < ApplicationRecord
     self.table_name = 'resource_quotas_usergroups'
 
-    belongs_to :resource_quota, inverse_of: :resource_quota_usergroups
-    belongs_to :usergroup, class_name: '::Usergroup', inverse_of: :resource_quota_usergroups
+    belongs_to :resource_quota, inverse_of: :resource_quotas_usergroups
+    belongs_to :usergroup, class_name: '::Usergroup', inverse_of: :resource_quotas_usergroups
   end
 end


### PR DESCRIPTION
Since the relation between Users/Usergroups and ResourceQuotas is many-to-many, the relations should reflect this correctly:

* Rename resource_quota_users to resource_quotas_users
* Rename resource_quota_usergroups to resource_quotas_usergroups

References:  [Ruby on Rails | Active Record Associations
](https://guides.rubyonrails.org/association_basics.html#the-has-and-belongs-to-many-association)