### PR TITLE
Remove react-dom/server dependency

### DIFF
--- a/webpack/components/ResourceQuotaForm/components/Resource/UtilizationProgress.js
+++ b/webpack/components/ResourceQuotaForm/components/Resource/UtilizationProgress.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   Progress,
@@ -12,10 +12,7 @@ import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
 import { translate as __ } from 'foremanReact/common/I18n';
 
 import './UtilizationProgress.scss';
-import {
-  findLargestFittingUnit,
-  areReactElementsEqual,
-} from '../../../../helper';
+import { findLargestFittingUnit } from '../../../../helper';
 
 const UtilizationProgress = ({
   cardId,
@@ -40,7 +37,8 @@ const UtilizationProgress = ({
     else if (resourceUtilizationPercent < 100) return ProgressVariant.warning;
     return ProgressVariant.danger;
   };
-  const updateResourceUtilizationView = () => {
+
+  const updateResourceUtilizationView = useCallback(() => {
     let newPercent;
     let newTooltipText;
 
@@ -93,13 +91,14 @@ const UtilizationProgress = ({
         </div>
       );
     }
-    if (resourceUtilizationPercent !== newPercent)
-      setResourceUtilizationPercent(newPercent);
-    if (!areReactElementsEqual(resourceUtilizationTooltipText, newTooltipText))
-      setResourceUtilizationTooltipText(newTooltipText);
-  };
+    setResourceUtilizationPercent(newPercent);
+    setResourceUtilizationTooltipText(newTooltipText);
+  }, [isNewQuota, resourceUnits, resourceUtilization, resourceValue]);
+
   // call it once
-  updateResourceUtilizationView();
+  useEffect(() => {
+    updateResourceUtilizationView();
+  }, [updateResourceUtilizationView]);
 
   return (
     <div>

--- a/webpack/helper.js
+++ b/webpack/helper.js
@@ -1,5 +1,3 @@
-import ReactDOMServer from 'react-dom/server';
-
 /**
  * Performs a deep equality comparison between two objects, including nested objects and arrays.
  * @param {Object} obj1 - The first object to compare.
@@ -35,16 +33,6 @@ const deepEqual = (obj1, obj2) => {
   }
 
   return true;
-};
-
-const areReactElementsEqual = (element1, element2) => {
-  const elementToStr = element =>
-    element && ReactDOMServer.renderToStaticMarkup(element);
-
-  const element1Str = elementToStr(element1);
-  const element2Str = elementToStr(element2);
-
-  return element1Str === element2Str;
 };
 
 /**
@@ -83,4 +71,4 @@ const findLargestFittingUnit = (value, unitList) => {
   return unitList[0];
 };
 
-export { deepEqual, deepCopy, findLargestFittingUnit, areReactElementsEqual };
+export { deepEqual, deepCopy, findLargestFittingUnit };


### PR DESCRIPTION


ReactDOMServer has been used to compare React components. Such comparison is not necessary and therefore, the dependency can be removed.

When placing the `updateResourceUtilizationView()`-call right in the component, it might be called several times due to re-rendering. In order to mitigate re-setting issues, it was important that the `updateResourceUtilizationView` function sets the corresponding values (`setResourceUtilizationPercent` and `setResourceUtilizationTooltipText`) only once/when they actually change.
To recognize such change, the helper-function `areReactElementsEqual` was implemented which compares React components. This adds a dependency to `react-dom/server`.

The comparison helper-function, and therefore the dependency, can be removed by moving `updateResourceUtilizationView()` in a `useEffect()` that is called only once (see [here](https://stackoverflow.com/a/55481525)).