### PR TITLE
Fix @patternfly/react-icons import paths

### DIFF
--- a/webpack/components/ResourceQuotaForm/components/Properties/index.js
+++ b/webpack/components/ResourceQuotaForm/components/Properties/index.js
@@ -16,10 +16,12 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 
-import UserIcon from '@patternfly/react-icons/dist/esm/icons/user-icon';
-import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
-import ClusterIcon from '@patternfly/react-icons/dist/esm/icons/cluster-icon';
-import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
+import {
+  UserIcon,
+  UsersIcon,
+  ClusterIcon,
+  SyncAltIcon,
+} from '@patternfly/react-icons';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 import { dispatchAPICallbackToast } from '../../../../api_helper';

--- a/webpack/components/ResourceQuotaForm/components/Resource/UtilizationProgress.js
+++ b/webpack/components/ResourceQuotaForm/components/Resource/UtilizationProgress.js
@@ -7,7 +7,7 @@ import {
   ProgressMeasureLocation,
   Tooltip,
 } from '@patternfly/react-core';
-import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
+import SyncAltIcon from '@patternfly/react-icons';
 
 import { translate as __ } from 'foremanReact/common/I18n';
 


### PR DESCRIPTION
Change from explicit
```
@patternfly/react-icons/dist/esm/icons/*
```
to
```
@patternfly/react-icons
```
due to import resolution in RPM build (see [here](https://download.copr.fedorainfracloud.org/results/@theforeman/plugins-nightly-staging-scratch-5a1aef52-3261-57f8-9b68-b1b25f2c9fe3/rhel-8-x86_64/07428570-rubygem-foreman_resource_quota/builder-live.log.gz)).