### PR TITLE
Fix ForemanTasks constant reference

### DIFF
--- a/lib/foreman_resource_quota/engine.rb
+++ b/lib/foreman_resource_quota/engine.rb
@@ -45,7 +45,9 @@ module ForemanResourceQuota
     end
 
     # Register ForemanTasks-based recurring logic/scheduled tasks
-    initializer 'foreman_resource_quota.register_scheduled_tasks', before: :finisher_hook do |_app|
+    initializer 'foreman_resource_quota.register_scheduled_tasks',
+      before: :finisher_hook,
+      after: :build_middleware_stack do |_app| # ForemanTasks::Task becomes only available after this hook
       action_paths = [ForemanResourceQuota::Engine.root.join('lib/foreman_resource_quota/async')]
       ::ForemanTasks.dynflow.config.eager_load_paths.concat(action_paths)
 


### PR DESCRIPTION
Resolves the `uninitialized constant ForemanTasks::Task` error ([failing action](https://github.com/ATIX-AG/foreman_resource_quota/actions/runs/12745185833/job/35518696430#step:21:13)).

This might be an effect of Rails 7 - however, we must be more precise about when Rails initializers are called that rely on ForemanTasks.