### PR TITLE
Fix taxonomy hiding of loc/org in API

### DIFF
--- a/app/controllers/foreman_resource_quota/api/v2/resource_quotas_controller.rb
+++ b/app/controllers/foreman_resource_quota/api/v2/resource_quotas_controller.rb
@@ -11,13 +11,10 @@ module ForemanResourceQuota
           resource_id 'resource_quota'
           api_version 'v2'
           api_base_url '/foreman_resource_quota/api'
-        end
-
-        begin
-          # add backwords compatibility here, the method is only available for Foreman 3.14
-          hide_taxonomy_options
-        rescue NameError
-          # we can ignore the error
+          # resource quota are not bound to org/loc - so we remove the parameters from api here
+          # loc/org are inherited from the ::Api::V2::BaseController in Foreman
+          param :location_id, Integer, show: false
+          param :organization_id, Integer, show: false
         end
 
         before_action :find_resource, only: %i[show update destroy]


### PR DESCRIPTION
The Foreman fix to remove taxonomy parameters from API does not work well because it overwrites the plugin's resource description (see https://github.com/theforeman/foreman/pull/10322#issuecomment-2596161372). This patch implements the same fix as introduced in Foreman directly but in its own resource description. 