### PR TITLE
Explicitly define npm and node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "foreman_resource_quota",
   "version": "1.0.0",
+  "engines": {
+    "node": ">= 18.0.0 < 21.0.0",
+    "npm": ">= 10.0.0"
+  },
   "description": "DESCRIPTION",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Define versions due to dependabot dropping npm v6 support and it seems to run with npm v6 per default (see [here](https://github.com/ATIX-AG/foreman_resource_quota/pull/102#issuecomment-2603998153)). Adding versions according to Foreman definitions at the time:

https://github.com/theforeman/foreman/blob/develop/.github/matrix.json

I'm not sure how dependabot determines the npm version to run. The package.json is an educated guess. However, another option would be to define version 6 to be ignored in the dependabot versions:

https://stackoverflow.com/questions/65736404/configure-npm-version-for-dependabot#77462635

AFAICT, we can only test this by merging once and checking whether the dependabot PRs work again.