### PR TITLE
Remove deprecated behavior of missing_hosts API

### DIFF
--- a/app/controllers/foreman_resource_quota/api/v2/resource_quotas_controller.rb
+++ b/app/controllers/foreman_resource_quota/api/v2/resource_quotas_controller.rb
@@ -46,7 +46,6 @@ module ForemanResourceQuota
           N_('Show resources could not be determined when calculating utilization')
         param :id, :identifier, required: true
         def missing_hosts
-          @resource_quota.determine_utilization
           process_response @resource_quota
         end
 


### PR DESCRIPTION
Resource Quota utilization is stored in DB and shall not be re-computed when triggering the missing_hosts API endpoint.