### PR TITLE
Improve error handling and edge cases of UnitInputSelection

### DIFF
--- a/webpack/components/ResourceQuotaForm/ResourceQuotaFormConstants.js
+++ b/webpack/components/ResourceQuotaForm/ResourceQuotaFormConstants.js
@@ -19,14 +19,14 @@ export const RESOURCE_NAME_DISK = 'Disk space';
 /* Resource units (order the units with increasing factor!) */
 export const RESOURCE_UNIT_CPU = [{ symbol: 'cores', factor: 1 }];
 export const RESOURCE_UNIT_MEMORY = [
-  { symbol: 'MB', factor: 1 },
-  { symbol: 'GB', factor: 1024 },
-  { symbol: 'TB', factor: 1024 * 1024 },
+  { symbol: 'MiB', factor: 1 },
+  { symbol: 'GiB', factor: 1024 },
+  { symbol: 'TiB', factor: 1024 * 1024 },
 ];
 export const RESOURCE_UNIT_DISK = [
-  { symbol: 'GB', factor: 1 },
-  { symbol: 'TB', factor: 1024 },
-  { symbol: 'PB', factor: 1024 * 1024 },
+  { symbol: 'GiB', factor: 1 },
+  { symbol: 'TiB', factor: 1024 },
+  { symbol: 'PiB', factor: 1024 * 1024 },
 ];
 
 /* Resource value bounds */

--- a/webpack/components/ResourceQuotaForm/components/Resource/UnitInputField.js
+++ b/webpack/components/ResourceQuotaForm/components/Resource/UnitInputField.js
@@ -61,10 +61,7 @@ const UnitInputField = ({
   }, [minValue, maxValue, selectedUnit]);
 
   /* text for float errors */
-  const errorTextNatural = useCallback(
-    () => __('Value must be a natural number.'),
-    []
-  );
+  const errorTextNatural = useCallback(() => __('Value must be a number.'), []);
 
   /* text for float inputs (rounding) */
   const warningTextRounded = useCallback(

--- a/webpack/components/ResourceQuotaForm/components/Resource/__test__/UnitInputField.test.js
+++ b/webpack/components/ResourceQuotaForm/components/Resource/__test__/UnitInputField.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import LabelIcon from 'foremanReact/components/common/LabelIcon';
+
+import UnitInputField from '../UnitInputField';
+
+const getDefaultProps = () => ({
+  initialValue: 0,
+  onChange: jest.fn(),
+  isDisabled: false,
+  handleInputValidation: jest.fn(),
+  units: [
+    { symbol: 'MiB', factor: 1 },
+    { symbol: 'GiB', factor: 1024 },
+  ],
+  labelIcon: <LabelIcon text="Descriptive title." />,
+  minValue: 0,
+  maxValue: 5,
+});
+
+const fixtureDefault = {
+  'should render default': {
+    ...getDefaultProps(),
+  },
+};
+
+const fixtureSingleUnit = {
+  'should render without dropdown (single unit)': {
+    ...getDefaultProps(),
+    units: [{ symbol: 'cores', factor: 1 }],
+  },
+};
+
+const fixtureDisabled = {
+  'should render as disabled field': {
+    ...getDefaultProps(),
+    isDisabled: true,
+  },
+};
+
+describe('UnitInputField', () => {
+  testComponentSnapshotsWithFixtures(UnitInputField, fixtureDefault);
+  testComponentSnapshotsWithFixtures(UnitInputField, fixtureSingleUnit);
+  testComponentSnapshotsWithFixtures(UnitInputField, fixtureDisabled);
+
+  it('triggers handleInputValidation on unit change', async () => {
+    const props = getDefaultProps();
+
+    render(<UnitInputField {...props} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 3 } });
+
+    // gets called (1.) with initialValue and (2.) the simulated change
+    expect(props.onChange).toHaveBeenCalledTimes(2);
+    expect(props.onChange).toHaveBeenCalledWith(props.initialValue);
+    expect(props.onChange).toHaveBeenLastCalledWith(3);
+    expect(props.handleInputValidation).toHaveBeenCalledTimes(2);
+    expect(props.handleInputValidation).toHaveBeenCalledWith(true);
+  });
+
+  test('triggers onChange with rounded value', () => {
+    const props = getDefaultProps();
+
+    render(<UnitInputField {...props} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 3.5 } });
+
+    // gets called (1.) with initialValue and (2.) the simulated change
+    expect(props.onChange).toHaveBeenCalledTimes(2);
+    expect(props.onChange).toHaveBeenCalledWith(props.initialValue);
+    expect(props.onChange).toHaveBeenLastCalledWith(3);
+    expect(props.handleInputValidation).toHaveBeenCalledTimes(2);
+    expect(props.handleInputValidation).toHaveBeenCalledWith(true);
+  });
+
+  test('does not trigger onChange when value out of bounds', () => {
+    const props = getDefaultProps();
+
+    render(<UnitInputField {...props} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: props.maxValue + 1 } });
+
+    // onChange only called for initialValue
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith(props.initialValue);
+    // handleInputValidation called with false => invalid
+    expect(props.handleInputValidation).toHaveBeenCalledTimes(2);
+    expect(props.handleInputValidation).toHaveBeenLastCalledWith(false);
+  });
+
+  test('does not trigger onChange when value is not a number', () => {
+    const props = getDefaultProps();
+
+    render(<UnitInputField {...props} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'no number' } });
+
+    // onChange only called for initialValue
+    expect(props.onChange).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith(props.initialValue);
+    // handleInputValidation called with false => invalid
+    expect(props.handleInputValidation).toHaveBeenCalledTimes(2);
+    expect(props.handleInputValidation).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/webpack/components/ResourceQuotaForm/components/Resource/__test__/__snapshots__/UnitInputField.test.js.snap
+++ b/webpack/components/ResourceQuotaForm/components/Resource/__test__/__snapshots__/UnitInputField.test.js.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnitInputField should render as disabled field 1`] = `
+<FormGroup
+  fieldId="quota-limit-resource-quota-form-group"
+  helperText={
+    <FormHelperText
+      isHidden={true}
+    >
+      
+    </FormHelperText>
+  }
+  helperTextInvalid=""
+  label="Quota Limit"
+  labelIcon={
+    <LabelIcon
+      text="Descriptive title."
+    />
+  }
+  validated="default"
+>
+  <InputGroup>
+    <TextInput
+      id="reg_token_life_time_input"
+      isDisabled={true}
+      max={5}
+      min={0}
+      onChange={[Function]}
+      validated="default"
+      value={0}
+    />
+    <Dropdown
+      dropdownItems={
+        Array [
+          <DropdownItem
+            id="unit-dropdownitem-mib"
+          >
+            MiB
+          </DropdownItem>,
+          <DropdownItem
+            id="unit-dropdownitem-gib"
+          >
+            GiB
+          </DropdownItem>,
+        ]
+      }
+      isOpen={false}
+      onSelect={[Function]}
+      toggle={
+        <DropdownToggle
+          isDisabled={true}
+          onToggle={[Function]}
+        >
+          MiB
+        </DropdownToggle>
+      }
+    />
+  </InputGroup>
+</FormGroup>
+`;
+
+exports[`UnitInputField should render default 1`] = `
+<FormGroup
+  fieldId="quota-limit-resource-quota-form-group"
+  helperText={
+    <FormHelperText
+      isHidden={true}
+    >
+      
+    </FormHelperText>
+  }
+  helperTextInvalid=""
+  label="Quota Limit"
+  labelIcon={
+    <LabelIcon
+      text="Descriptive title."
+    />
+  }
+  validated="default"
+>
+  <InputGroup>
+    <TextInput
+      id="reg_token_life_time_input"
+      isDisabled={false}
+      max={5}
+      min={0}
+      onChange={[Function]}
+      validated="default"
+      value={0}
+    />
+    <Dropdown
+      dropdownItems={
+        Array [
+          <DropdownItem
+            id="unit-dropdownitem-mib"
+          >
+            MiB
+          </DropdownItem>,
+          <DropdownItem
+            id="unit-dropdownitem-gib"
+          >
+            GiB
+          </DropdownItem>,
+        ]
+      }
+      isOpen={false}
+      onSelect={[Function]}
+      toggle={
+        <DropdownToggle
+          isDisabled={false}
+          onToggle={[Function]}
+        >
+          MiB
+        </DropdownToggle>
+      }
+    />
+  </InputGroup>
+</FormGroup>
+`;
+
+exports[`UnitInputField should render without dropdown (single unit) 1`] = `
+<FormGroup
+  fieldId="quota-limit-resource-quota-form-group"
+  helperText={
+    <FormHelperText
+      isHidden={true}
+    >
+      
+    </FormHelperText>
+  }
+  helperTextInvalid=""
+  label="Quota Limit"
+  labelIcon={
+    <LabelIcon
+      text="Descriptive title."
+    />
+  }
+  validated="default"
+>
+  <InputGroup>
+    <TextInput
+      id="reg_token_life_time_input"
+      isDisabled={false}
+      max={5}
+      min={0}
+      onChange={[Function]}
+      validated="default"
+      value={0}
+    />
+    <InputGroupText>
+      cores
+    </InputGroupText>
+  </InputGroup>
+</FormGroup>
+`;


### PR DESCRIPTION
This PR resolves three issues with the React component `UnitInputField` which is used when typing the resource limits of a Resource Quota.

# From error to floor warning

The UnitInputField prints an error if a user wants to type a value which is a float in the corresponding base unit, for example 5.5 MiB for the memory limit. 

Instead of showing an error, we introduce a warning which says that the value is rounded to the next lower value (5.0 MiB):

*Before*

![image](https://github.com/user-attachments/assets/25390725-a1c7-4870-b19c-7df42d98ac3f)

*New*

![Screenshot from 2025-02-10 16-40-07](https://github.com/user-attachments/assets/f8c4a0cf-4657-4c06-9899-d63c649fe1a5)




---

# No more natural

Moreover, we introduce a more generic error message if no number is given (removing the word 'natural' as it is quite mathematical/technical):

*Before*

![image](https://github.com/user-attachments/assets/4f914c7d-8fd2-4a60-ae16-4c3854acb78d)


*New*

![Screenshot from 2025-02-10 16-53-57](https://github.com/user-attachments/assets/bba72c50-c453-4d44-aea7-09100320605f)



---

# Actually, it's Mebi

We are internally using MebiBytes (MiB) for memory and disk space. However, the UI stated "MB" and others.

*Before*

![image](https://github.com/user-attachments/assets/9c92a55e-71d9-4ba9-a33f-a78a0dce5fd2)


*New*

![image](https://github.com/user-attachments/assets/b92cbe2e-57ff-45b4-8b0d-c7a5013ec378)

