### PR TITLE
Add Resource Quota option to Register Host

### DIFF
--- a/app/controllers/foreman_resource_quota/concerns/registration_commands_controller_extensions.rb
+++ b/app/controllers/foreman_resource_quota/concerns/registration_commands_controller_extensions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ForemanResourceQuota
+  module Concerns
+    module RegistrationCommandsControllerExtensions
+      extend ActiveSupport::Concern
+
+      def plugin_data
+        quotas = ResourceQuota.authorized(:view_resource_quotas)
+                              .order(:name)
+                              .map { |quota| { id: quota.id, name: quota.name } }
+        data = { availableQuotas: quotas }
+
+        super.merge(data)
+      end
+    end
+  end
+end

--- a/lib/foreman_resource_quota/engine.rb
+++ b/lib/foreman_resource_quota/engine.rb
@@ -41,6 +41,9 @@ module ForemanResourceQuota
       ::Usergroup.include ForemanResourceQuota::UsergroupExtensions
       ::Host::Managed.include ForemanResourceQuota::HostManagedExtensions
 
+      # Controller extensions
+      ::RegistrationCommandsController.prepend ForemanResourceQuota::Concerns::RegistrationCommandsControllerExtensions
+
       # Api controller extensions
       ::Api::V2::HostsController.include ForemanResourceQuota::Concerns::Api::V2::HostsControllerExtensions
       ::Api::V2::UsersController.include ForemanResourceQuota::Concerns::Api::V2::UsersControllerExtensions

--- a/lib/foreman_resource_quota/register.rb
+++ b/lib/foreman_resource_quota/register.rb
@@ -61,6 +61,9 @@ Foreman::Plugin.register :foreman_resource_quota do
     parent: :configure_menu,
     after: :common_parameters
 
+  # add React/webpack extensions via global_index.js
+  register_global_js_file 'global'
+
   # add API extension
   extend_rabl_template 'api/v2/hosts/main', 'foreman_resource_quota/api/v2/hosts/resource_quota'
   extend_rabl_template 'api/v2/users/main', 'foreman_resource_quota/api/v2/users/resource_quota'

--- a/webpack/components/extensions/RegistrationCommands/fields/ResourceQuota.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/ResourceQuota.js
@@ -1,0 +1,143 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  FormHelperText,
+  HelperTextItem,
+  HelperText,
+} from '@patternfly/react-core';
+
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const ResourceQuota = ({
+  availableQuotas,
+  selectedQuota,
+  pluginValues,
+  onChange,
+  isLoading,
+  handleInvalidField,
+}) => {
+  const validateResouceQuotaField = (selected, all) => {
+    if (!all) {
+      return true;
+    }
+
+    if (all.filter(quota => quota === selected)) {
+      return true;
+    }
+    return false;
+  };
+
+  const updatePluginValues = quotas => {
+    onChange({ availableQuotas: quotas });
+    handleInvalidField(
+      'Resource Quota',
+      validateResouceQuotaField(selectedQuota, availableQuotas)
+    );
+  };
+
+  const helperText = valid => {
+    if (valid) {
+      return '';
+    }
+    return 'Invalid Resource Quota!';
+  };
+
+  const helperValidated = valid => {
+    if (valid) {
+      return 'default';
+    }
+    return 'error';
+  };
+
+  const onSelect = (_e, value) => {
+    updatePluginValues([...selectedQuota, value]);
+  };
+
+  // Validate field when hostgroup is changed (host group may have some keys)
+  useEffect(() => {
+    handleInvalidField(
+      'Activation Keys',
+      validateResouceQuotaField(selectedQuota, availableQuotas)
+    );
+  }, [handleInvalidField, selectedQuota, availableQuotas]);
+
+  useEffect(() => {
+    if (availableQuotas?.length === 1) {
+      onChange({ availableQuotas: [availableQuotas[0].name] });
+    }
+  }, [availableQuotas, onChange]);
+
+  return (
+    <FormGroup
+      label={__('Resource Quota')}
+      fieldId="resource_quota_field"
+      isRequired
+    >
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem
+            variant={helperValidated()}
+            {...(helperValidated() === 'error' && {
+              icon: <ExclamationCircleIcon />,
+            })}
+          >
+            {helperText()}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+      <FormSelect
+        id="selection"
+        validated={validateResouceQuotaField(selectedQuota, availableQuotas)}
+        value={selectedQuota?.name}
+        onChange={onSelect}
+        aria-label="FormSelect Input"
+      >
+        {availableQuotas &&
+          availableQuotas.map((option, index) => (
+            <FormSelectOption
+              key={index}
+              value={option.id}
+              label={option.name}
+            />
+          ))}
+      </FormSelect>
+    </FormGroup>
+  );
+};
+
+ResourceQuota.propTypes = {
+  availableQuotas: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    })
+  ),
+  selectedQuota: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+  }),
+  pluginValues: PropTypes.shape({
+    availableQuotas: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number,
+        name: PropTypes.string,
+      })
+    ),
+  }),
+  onChange: PropTypes.func.isRequired,
+  handleInvalidField: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+};
+
+ResourceQuota.defaultProps = {
+  availableQuotas: undefined,
+  selectedQuota: undefined,
+  pluginValues: {},
+  isLoading: false,
+};
+
+export default ResourceQuota;

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'foremanReact/common/helpers';
+
+import ResourceQuota from './fields/ResourceQuota';
+
+export const RegistrationResourceQuota = ({
+  pluginValues,
+  pluginData,
+  onChange,
+  handleInvalidField,
+  isLoading,
+}) => {
+  useEffect(() => {
+    onChange({ availableQuotas: [] });
+  }, [onChange]);
+
+  useEffect(() => {
+    onChange({ availableQuotas: pluginData?.availableQuotas });
+  }, [onChange, pluginData?.availableQuotas]);
+
+  return (
+    <ResourceQuota
+      availableQuotas={pluginData?.availableQuotas}
+      selectedKeys={pluginValues?.selectedQuota || {}}
+      pluginValues={pluginValues}
+      onChange={onChange}
+      handleInvalidField={handleInvalidField}
+      isLoading={isLoading}
+    />
+  );
+};
+
+RegistrationResourceQuota.propTypes = {
+  pluginValues: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  pluginData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  onChange: PropTypes.func,
+  handleInvalidField: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+RegistrationResourceQuota.defaultProps = {
+  pluginValues: {},
+  pluginData: {},
+  isLoading: false,
+  onChange: noop,
+  handleInvalidField: noop,
+};

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,4 +1,14 @@
-// Placeholder to initialize routes (compare foreman_ansible)
+import React from 'react';
+import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
+
+import { RegistrationResourceQuota } from './components/extensions/RegistrationCommands/index';
+
+addGlobalFill(
+  'registrationGeneral',
+  '[foreman_resource_quota]RegistrationResourceQuota',
+  <RegistrationResourceQuota key="foreman_resource_quota-reg-rq" />,
+  100
+);
 
 /*
 import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';


### PR DESCRIPTION
This PR is a result of #53.

The Register Host procedure is currently not integrated in the Foreman Resource Quota plugin e.g. installing the plugin breaks the procedure for now. The main issue is that a user cannot select/assign a Resource Quota when the new host shall be registered/created on Foreman-side.

The proposed solution adds a field to the Register Host UI which allows a user to select a Resource Quota when generating the registration command. The chosen Resource Quota shall than be included in the registration template.

---

## State of this PR

The given commis is a preliminary version which adds a UI extension to the React-based Register Host UI. When running the code of this PR on a current Foreman (Rails 7, Patternfly 5), the following extension is loaded:

![image](https://github.com/user-attachments/assets/13f3025e-582e-4201-82b1-23771f6a9f16)
