### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/lib/foreman_resource_quota/version.rb
+++ b/lib/foreman_resource_quota/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForemanResourceQuota
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
I would like to bump a new version for Foreman < 3.15 before merging the Patternfly change because we had quite a lot of improvements in between. 