### PR TITLE
Add unassigned quota as default quota

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ inherit_mode:
   merge:
     - Exclude
 
+Rails/LexicallyScopedActionFilter:
+  Exclude:
+    - 'app/controllers/foreman_resource_quota/concerns/api/v2/hosts_controller_extensions.rb'
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: 2

--- a/app/controllers/foreman_resource_quota/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_resource_quota/concerns/api/v2/hosts_controller_extensions.rb
@@ -5,13 +5,34 @@ module ForemanResourceQuota
     module Api
       module V2
         module HostsControllerExtensions
+          extend ActiveSupport::Concern
+
+          included do
+            before_action :check_if_quota_is_set, only: %i[create update]
+          end
+
           extend ::Apipie::DSL::Concern
+
           update_api(:create, :update) do
             param :host, Hash do
               param :resource_quota_id, :number, required: false,
                 desc: N_('Resource Quota ID.
                          This field is required if the setting `resource_quota_optional_assignment` is set to false.')
             end
+          end
+
+          private
+
+          def check_if_quota_is_set # rubocop:disable Metrics/AbcSize
+            return if User.current.quota_assignment_optional?
+            quota = if User.current&.admin?
+                      ResourceQuota.where(id: params['host']['resource_quota_id']).first
+                    else
+                      User.current.resource_quotas.where(id: params['host']['resource_quota_id']).first
+                    end
+            return unless quota.nil? || quota.unassigned?
+            render_error :custom_error, status: :unprocessable_entity,
+locals: { message: 'No valid resource quota provided' }
           end
         end
       end

--- a/app/helpers/foreman_resource_quota/hosts_helper.rb
+++ b/app/helpers/foreman_resource_quota/hosts_helper.rb
@@ -2,17 +2,28 @@
 
 module ForemanResourceQuota
   module HostsHelper
-    def resource_quota_select(form, user_quotas)
-      blank_opt = { include_blank: true }
-      select_items = user_quotas.order(:name)
+    def resource_quota_select(form, user_quotas, selected, assignment_optional, host_quota)
+      select_opts = { include_blank: false,
+                      selected: selected }
+      html_opts = { label: _('Resource Quota'),
+                    required: !assignment_optional,
+                    help_inline: if assignment_optional
+                                   _('Define the Resource Quota this host counts to.')
+                                 elsif host_quota.nil? ||
+                                       host_quota == ForemanResourceQuota::ResourceQuota.unassigned.id
+                                   format(_("Quota required! Choosing '%s' by default, change here if needed!"),
+                                     user_quotas.find(selected))
+                                 else
+                                   _('Resource quota assignment required!')
+                                 end }
+
       select_f form,
         :resource_quota_id,
-        select_items,
+        user_quotas,
         :id,
         :to_label,
-        blank_opt,
-        label: _('Resource Quota'),
-        help_inline: _('Define the Resource Quota this host counts to.')
+        select_opts,
+        html_opts
     end
   end
 end

--- a/app/lib/foreman_resource_quota/exceptions.rb
+++ b/app/lib/foreman_resource_quota/exceptions.rb
@@ -8,5 +8,6 @@ module ForemanResourceQuota
     class HostResourcesException < ResourceQuotaException; end
     class ResourceQuotaUtilizationException < ResourceQuotaException; end
     class HostNotFoundException < ResourceQuotaException; end
+    class UnassignedQuotaDeletionException < ResourceQuotaException; end
   end
 end

--- a/app/models/concerns/foreman_resource_quota/user_extensions.rb
+++ b/app/models/concerns/foreman_resource_quota/user_extensions.rb
@@ -4,12 +4,39 @@ module ForemanResourceQuota
   module UserExtensions
     extend ActiveSupport::Concern
     included do
+      after_create :set_unassigned_quota
+
       has_many :resource_quotas_users, class_name: 'ForemanResourceQuota::ResourceQuotaUser', dependent: :destroy,
         inverse_of: :user
       has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quotas_users
       attribute :resource_quota_is_optional, :boolean, default: false
 
       scoped_search relation: :resource_quotas, on: :name, complete_value: true, rename: :resource_quota
+
+      def assignable_resource_quotas
+        resource_quotas.assignable
+      end
+
+      def quota_assignment_optional?
+        Setting['resource_quota_optional_assignment'] || resource_quota_is_optional
+      end
+
+      def show_unassigned_hosts_warning?
+        return false if Setting['resource_quota_optional_assignment']
+        (admin? &&
+         !ForemanResourceQuota::ResourceQuota.unassigned.hosts.empty?) ||
+          (!admin? &&
+           !resource_quota_is_optional &&
+           !ForemanResourceQuota::ResourceQuota.unassigned.hosts.where(owner: self).empty?)
+      end
+
+      private
+
+      def set_unassigned_quota
+        return if resource_quotas.include?(ForemanResourceQuota::ResourceQuota.unassigned)
+
+        resource_quotas << ForemanResourceQuota::ResourceQuota.unassigned
+      end
     end
   end
 end

--- a/app/models/concerns/foreman_resource_quota/usergroup_extensions.rb
+++ b/app/models/concerns/foreman_resource_quota/usergroup_extensions.rb
@@ -4,11 +4,29 @@ module ForemanResourceQuota
   module UsergroupExtensions
     extend ActiveSupport::Concern
     included do
+      after_create :set_unassigned_quota
+
       has_many :resource_quotas_usergroups, class_name: 'ForemanResourceQuota::ResourceQuotaUsergroup',
         dependent: :destroy, inverse_of: :usergroup
       has_many :resource_quotas, class_name: 'ForemanResourceQuota::ResourceQuota', through: :resource_quotas_usergroups
 
       scoped_search relation: :resource_quotas, on: :name, complete_value: true, rename: :resource_quota
+
+      def assignable_resource_quotas
+        resource_quotas.assignable
+      end
+
+      def quota_assignment_optional?
+        Setting['resource_quota_optional_assignment']
+      end
+
+      private
+
+      def set_unassigned_quota
+        return if resource_quotas.include?(ForemanResourceQuota::ResourceQuota.unassigned)
+
+        resource_quotas << ForemanResourceQuota::ResourceQuota.unassigned
+      end
     end
   end
 end

--- a/app/views/foreman_resource_quota/resource_quotas/index.html.erb
+++ b/app/views/foreman_resource_quota/resource_quotas/index.html.erb
@@ -6,6 +6,9 @@
 <% end %>
 
 <% title _('Resource Quotas') %>
+  <%  if User.current.show_unassigned_hosts_warning? %>
+  <%= alert :class => 'alert-warning', :header => _('You have unassigned hosts!'), text: "The setting 'resource_quota_optional_assignment' is set to 'No' but there are hosts without quota assignment. Please check your hosts' quota assignments! " %>
+<% end %>
 
 <%= title_actions react_component('CreateResourceQuotaModal') %>
 
@@ -22,8 +25,10 @@
   </thead>
   <tbody>
     <% @resource_quotas.each do |quota|
+      showAssignmentWarning = quota.unassigned? && User.current.show_unassigned_hosts_warning?
          react_data = {
            "isNewQuota": false,
+           "showAssignmentWarning": showAssignmentWarning,
            "initialProperties": {
              "id": quota.id,
              "name": quota.name,
@@ -31,6 +36,7 @@
              "cpu_cores": quota.cpu_cores,
              "memory_mb": quota.memory_mb,
              "disk_gb": quota.disk_gb,
+             "unassigned": quota.unassigned?,
            },
          }
     %>
@@ -43,9 +49,11 @@
         <td><%= h(quota.memory_mb) %></td>
         <td><%= h(quota.disk_gb) %></td>
         <td>
+          <% unless quota.unassigned? %>
           <%= action_buttons(
                 display_delete_if_authorized(hash_for_foreman_resource_quota_resource_quota_path(id: quota), data: { confirm: _("Delete %s?") % quota.name})
-              ) %>
+          ) %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/hosts/_form_quota_fields.html.erb
+++ b/app/views/hosts/_form_quota_fields.html.erb
@@ -1,4 +1,16 @@
 <%
-  user_quotas = User.current&.admin? ? ForemanResourceQuota::ResourceQuota.all : User.current.resource_quotas
+  user_quotas = User.current&.admin? ? ForemanResourceQuota::ResourceQuota.all : User.current.resource_quotas.distinct
+  user_quotas = user_quotas.assignable if !User.current.quota_assignment_optional?
+  user_quotas = user_quotas.order(:name)
+  selected = @host.resource_quota_id
+  # show Unassigned as default when assignment is optional
+  # show first selectable quota when assignment is mandatory
+  if selected.nil? || selected == ForemanResourceQuota::ResourceQuota.unassigned.id
+    if User.current.quota_assignment_optional?
+      selected = ForemanResourceQuota::ResourceQuota.unassigned.id
+    else
+      selected = user_quotas&.first&.id
+    end
+  end
 %>
-<%= resource_quota_select form, user_quotas %>
+<%= resource_quota_select form, user_quotas, selected, User.current.quota_assignment_optional?, @host.resource_quota_id %>

--- a/app/views/users/_form_quota_tab.html.erb
+++ b/app/views/users/_form_quota_tab.html.erb
@@ -10,7 +10,7 @@
     :label_help => _("It is optional for a user to assign a quota when creating new hosts") %>
 <% end %>
 
-<%= multiple_checkboxes(form, :resource_quotas, resource, ForemanResourceQuota::ResourceQuota, :label => _("Resource Quotas")) %>
+<%= multiple_checkboxes(form, :resource_quotas, resource, ForemanResourceQuota::ResourceQuota.assignable, :label => _("Resource Quotas")) %>
 
 <% if resource_type == :user %>
   <% usergroups = @user.cached_usergroups.includes(:resource_quotas).distinct %>
@@ -34,7 +34,7 @@
             <% unless usergroup.resource_quotas.map(&:name).any? %>
                 <li data-id="<%= usergroup.id %>" class="list-group-item"><%= _('This group has no quotas') %></li>
             <%end %>
-            <% usergroup.resource_quotas.map(&:name).each do |quota_name| %>
+            <% usergroup.assignable_resource_quotas.map(&:name).each do |quota_name| %>
               <li data-id="<%= usergroup.id %>" class="list-group-item"><%= quota_name %></li>
             <% end %>
           <% end %>

--- a/db/migrate/20250410082728_add_unassigned_flag_to_resource_quota.rb
+++ b/db/migrate/20250410082728_add_unassigned_flag_to_resource_quota.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUnassignedFlagToResourceQuota < ActiveRecord::Migration[6.1]
+  def change
+    add_column :resource_quotas, :unassigned, :bool, null: false, default: false
+  end
+end

--- a/db/seeds.d/030-unassigned_quota.rb
+++ b/db/seeds.d/030-unassigned_quota.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Default Quota "Unassigned"
+ForemanResourceQuota::ResourceQuota.without_auditing do # rubocop:disable Metrics/BlockLength
+  unassigned = ForemanResourceQuota::ResourceQuota.where(
+    name: 'Unassigned',
+    unassigned: true,
+    description: 'Here, you can see all hosts without a dedicated quota.'
+  ).first_or_create
+
+  # Add default quota to all users and usergroups
+  User.without_auditing do
+    User.all.each do |user|
+      unless user.resource_quotas.include?(unassigned)
+        user.resource_quotas << unassigned
+        user.save!
+      end
+    end
+  end
+
+  Usergroup.without_auditing do
+    Usergroup.all.each do |usergroup|
+      unless usergroup.resource_quotas.include?(unassigned)
+        usergroup.resource_quotas << unassigned
+        usergroup.save!
+      end
+    end
+  end
+
+  # Move all hosts without a quota to quota "Unassigned"
+  Host.without_auditing do
+    Host.all.each do |host|
+      host.update(resource_quota: unassigned) if host.resource_quota.nil?
+    end
+  end
+end

--- a/test/controllers/api/v2/resource_quotas_test.rb
+++ b/test/controllers/api/v2/resource_quotas_test.rb
@@ -10,7 +10,13 @@ module ForemanResourceQuota
         def setup
           User.current = User.find_by login: 'admin'
           @quota = FactoryBot.create :resource_quota
+          @unassigned = ForemanResourceQuota::ResourceQuota.where(
+            name: 'Unassigned',
+            unassigned: true,
+            description: 'Here, you can see all hosts without a dedicated quota.'
+          ).first_or_create
           as_admin { @quota.save! }
+          as_admin { @unassigned.save! }
         end
 
         test 'should get index with quotas' do

--- a/test/controllers/concerns/api/v2/host_controller_extensions_test.rb
+++ b/test/controllers/concerns/api/v2/host_controller_extensions_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanResourceQuota
+  module Concerns
+    module Api
+      module V2
+        class HostsControllerExtensionsTest < ActionController::TestCase
+          tests ::Api::V2::HostsController
+
+          def setup
+            User.current = User.find_by login: 'admin'
+            @unassigned = ForemanResourceQuota::ResourceQuota.where(
+              name: 'Unassigned',
+              unassigned: true,
+              description: 'Here, you can see all hosts without a dedicated quota.'
+            ).first_or_create
+            as_admin { @unassigned.save! }
+            Setting[:resource_quota_optional_assignment] = false
+          end
+
+          test 'should create host with unassigned (default) quota' do
+            Setting[:resource_quota_optional_assignment] = true
+            host_params = FactoryBot.attributes_for(:host, managed: false)
+            post :create, params: { host: host_params }
+            assert_response :created
+            assert_equal @unassigned.id, JSON.parse(response.body)['resource_quota_id'].to_i
+          end
+
+          test 'should fail to create host without assigned quota' do
+            host_params = FactoryBot.attributes_for(:host, managed: false)
+            post :create, params: { host: host_params }
+            assert_response :unprocessable_entity
+            assert_match(/No valid resource quota provided/, JSON.parse(response.body)['error']['message'])
+            # still fails even when adding a second quota
+            quota = FactoryBot.create :resource_quota
+            as_admin { quota.save! }
+            post :create, params: { host: host_params }
+            assert_response :unprocessable_entity
+            assert_match(/No valid resource quota provided/, JSON.parse(response.body)['error']['message'])
+          end
+
+          test 'should fail to update host without assigned quota' do
+            Setting[:resource_quota_optional_assignment] = true
+            # create a host without a quota
+            as_admin do
+              host = FactoryBot.create(:host, owner: User.current, managed: false)
+              Setting[:resource_quota_optional_assignment] = false
+              put :update, params: { id: host.id, host: { name: host.name } }
+            end
+            assert_response :unprocessable_entity
+            assert_match(/No valid resource quota provided/, JSON.parse(response.body)['error']['message'])
+          end
+
+          test 'should update host with valied quota' do
+            Setting[:resource_quota_optional_assignment] = true
+            # create a host without a quota
+            as_admin do
+              quota = FactoryBot.create(:resource_quota)
+              host = FactoryBot.create(:host, owner: User.current, managed: false)
+              Setting[:resource_quota_optional_assignment] = false
+              put :update, params: { id: host.id, host: { name: host.name, resource_quota_id: quota.id } }
+            end
+            assert_response :success
+          end
+
+          test 'should succeed to create host with assigned quota' do
+            @quota = FactoryBot.create :resource_quota
+            as_admin { @quota.save! }
+            host_params = FactoryBot.attributes_for(:host, managed: false).merge(resource_quota_id: @quota.id)
+            post :create, params: { host: host_params }
+            assert_response :created
+            assert_equal @quota.id, JSON.parse(response.body)['resource_quota_id'].to_i
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/resource_quotas_controller_test.rb
+++ b/test/controllers/resource_quotas_controller_test.rb
@@ -7,6 +7,11 @@ module ForemanResourceQuota
     tests ForemanResourceQuota::ResourceQuotasController
 
     setup do
+      @unassigned = ForemanResourceQuota::ResourceQuota.where(
+        name: 'Unassigned',
+        unassigned: true,
+        description: 'Here, you can see all hosts without a dedicated quota.'
+      ).first_or_create
       @quota = FactoryBot.create :resource_quota
       User.current = User.find_by login: 'admin'
       as_admin { @quota.save! }

--- a/test/helpers/hosts_helper_test.rb
+++ b/test/helpers/hosts_helper_test.rb
@@ -9,26 +9,51 @@ module ForemanResourceQuota
 
     context 'optional quota assignment at host creation' do
       def setup
-        Setting[:resource_quota_optional_assignment] = true
+        @unassigned = ForemanResourceQuota::ResourceQuota.where(
+          name: 'Unassigned',
+          unassigned: true,
+          description: 'Here, you can see all hosts without a dedicated quota.'
+        ).first_or_create
+        @quotas = []
+        @quotas << (FactoryBot.create :resource_quota)
+        @quotas << (FactoryBot.create :resource_quota)
+        @quotas << (FactoryBot.create :resource_quota)
+        as_admin { @quotas.each(&:save!) }
+        @host = FactoryBot.create :host, resource_quota: @quotas.first
       end
 
-      test 'host edit page form' do
-        @host = FactoryBot.create :host
-        quotas = []
-        quotas << (FactoryBot.create :resource_quota)
-        quotas << (FactoryBot.create :resource_quota)
-        quotas << (FactoryBot.create :resource_quota)
-        as_admin { quotas.each(&:save!) }
-
+      test 'host edit page form with unassigned options for optional assignement' do
+        Setting[:resource_quota_optional_assignment] = true
         form = ''
         as_admin do
           form = form_for(@host) do |f|
-            resource_quota_select(f, ResourceQuota.all)
+            # def resource_quota_select(form, user_quotas, selected, assignment_optional, host_quota)
+            resource_quota_select(f, ResourceQuota.all, @host.resource_quota.id, true, @host.resource_quota_id)
           end
         end
-        quotas.each do |quota|
+
+        @quotas.each do |quota|
           assert form[quota.name]
         end
+        assert form[@unassigned.name]
+        assert form['Define the Resource Quota this host counts to.']
+      end
+
+      test 'host edit page form without unassigned options for mandatory assignment' do
+        Setting[:resource_quota_optional_assignment] = false
+        form = ''
+        as_admin do
+          form = form_for(@host) do |f|
+            # def resource_quota_select(form, user_quotas, selected, assignment_optional, host_quota)
+            resource_quota_select(f, ResourceQuota.assignable, @host.resource_quota.id, false, @host.resource_quota_id)
+          end
+        end
+
+        @quotas.each do |quota|
+          assert form[quota.name]
+        end
+        assert_nil form[@unassigned.name]
+        assert form['Resource quota assignment required!']
       end
     end
   end

--- a/test/models/concerns/user_extensions_test.rb
+++ b/test/models/concerns/user_extensions_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanResourceQuota
+  class UserExtensionTest < ActiveSupport::TestCase
+    include ForemanResourceQuota::ResourceQuotaHelper
+
+    def setup
+      @unassigned = ForemanResourceQuota::ResourceQuota.where(
+        name: 'Unassigned',
+        unassigned: true,
+        description: 'Here, you can see all hosts without a dedicated quota.'
+      ).first_or_create
+      @quota = FactoryBot.create(:resource_quota)
+      as_admin { @quota.save! }
+      @user = FactoryBot.create(:user)
+    end
+
+    test 'user created with unassigned quota by default' do
+      assert_includes @user.resource_quotas, @unassigned
+    end
+
+    test 'user has assignable quotas' do
+      @user.resource_quotas << @quota
+      assert_includes @user.assignable_resource_quotas, @quota
+      assert_not_includes @user.assignable_resource_quotas, @unassigned
+    end
+
+    test 'always return true when user quota assignement is optional' do
+      @user.resource_quota_is_optional = true
+      Setting['resource_quota_optional_assignment'] = true
+      assert @user.quota_assignment_optional?
+      # user setting should overwrite global setting
+      Setting['resource_quota_optional_assignment'] = false
+      assert @user.quota_assignment_optional?
+    end
+
+    test 'Only return false if user quota assignement is not optional' do
+      @user.resource_quota_is_optional = false
+      # global setting should overwrite user setting if true
+      Setting['resource_quota_optional_assignment'] = true
+      assert @user.quota_assignment_optional?
+      # if all settings are set to false, should return false
+      Setting['resource_quota_optional_assignment'] = false
+      assert_not @user.quota_assignment_optional?
+    end
+
+    test 'show warning if hosts unassigned and assignment not optional' do
+      @user.resource_quota_is_optional = false
+      Setting['resource_quota_optional_assignment'] = true
+      FactoryBot.create(:host, resource_quota: @unassigned, owner: @user)
+      Setting['resource_quota_optional_assignment'] = false
+      assert @user.show_unassigned_hosts_warning?
+    end
+
+    test 'do not show warning if hosts unassigned and assignment optional' do
+      @user.resource_quota_is_optional = false
+      # global setting should overwrite user setting if true
+      Setting['resource_quota_optional_assignment'] = true
+      FactoryBot.create(:host, resource_quota: @unassigned, owner: @user)
+      assert_not @user.show_unassigned_hosts_warning?
+    end
+  end
+end

--- a/test/models/concerns/usergroup_extensions_test.rb
+++ b/test/models/concerns/usergroup_extensions_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanResourceQuota
+  class UsergroupExtensionTest < ActiveSupport::TestCase
+    include ForemanResourceQuota::ResourceQuotaHelper
+
+    def setup
+      @unassigned = ForemanResourceQuota::ResourceQuota.where(
+        name: 'Unassigned',
+        unassigned: true,
+        description: 'Here, you can see all hosts without a dedicated quota.'
+      ).first_or_create
+      @quota = FactoryBot.create(:resource_quota)
+      as_admin { @quota.save! }
+      @usergroup = FactoryBot.create(:usergroup)
+    end
+
+    test 'usergroup created with unassigned quota by default' do
+      assert_includes @usergroup.resource_quotas, @unassigned
+    end
+
+    test 'usergroup has assignable quotas' do
+      @usergroup.resource_quotas << @quota
+      assert_includes @usergroup.assignable_resource_quotas, @quota
+      assert_not_includes @usergroup.assignable_resource_quotas, @unassigned
+    end
+
+    test 'usergroup quota assignment should correspond to global setting ' do
+      Setting['resource_quota_optional_assignment'] = true
+      assert @usergroup.quota_assignment_optional?
+      Setting['resource_quota_optional_assignment'] = false
+      assert_not @usergroup.quota_assignment_optional?
+    end
+  end
+end

--- a/test/models/resource_quota_test.rb
+++ b/test/models/resource_quota_test.rb
@@ -4,32 +4,62 @@ require 'test_plugin_helper'
 
 module ForemanResourceQuota
   class ResourceQuotaTest < ActiveSupport::TestCase
+    include Exceptions
     context 'optional quota assignment at host creation' do
       def setup
         Setting[:resource_quota_optional_assignment] = true
 
+        @unassigned = ForemanResourceQuota::ResourceQuota.where(
+          name: 'Unassigned',
+          unassigned: true,
+          description: 'Here, you can see all hosts without a dedicated quota.'
+        ).first_or_create
+        as_admin { @unassigned.save! }
         @quota = FactoryBot.create :resource_quota
+        as_admin { @quota.save! }
         @user = FactoryBot.create :user
         @usergroup = FactoryBot.create :usergroup
-        @host = FactoryBot.create :host
+        @host = FactoryBot.create :host, resource_quota: @quota
+      end
+
+      test 'unassigned quota available' do
+        assert_equal ResourceQuota.unassigned, @unassigned
+        assert_not_equal ResourceQuota.unassigned, @quota
+      end
+
+      test 'cannot delete unassigned quota' do
+        assert_raises UnassignedQuotaDeletionException do
+          @unassigned.destroy
+        end
+      end
+
+      test 'assignable quota scope' do
+        assert_includes ResourceQuota.assignable, @quota
+        assert_not_includes ResourceQuota.assignable, @unassigned
       end
 
       test 'hosts relation' do
-        @quota.hosts << @host
         assert_equal @host.id, @quota.hosts[0].id
         assert_equal @quota.id, @host.reload.resource_quota.id
+      end
+
+      test 'host quota is set to unassigned on quota deletion' do
+        @quota.destroy
+        assert_equal @host.reload.resource_quota, @unassigned
       end
 
       test 'users relation' do
         @quota.users << @user
         assert_equal @user.id, @quota.users[0].id
-        assert_equal @quota.id, @user.resource_quotas[0].id
+        assert_includes @user.resource_quotas, @unassigned
+        assert_includes @user.resource_quotas, @quota
       end
 
       test 'users relation delete user' do
         @quota.users << @user
         assert_equal @user.id, @quota.users[0].id
-        assert_equal @quota.id, @user.resource_quotas[0].id
+        assert_includes @user.resource_quotas, @unassigned
+        assert_includes @user.resource_quotas, @quota
         @user.destroy
         assert_empty @quota.reload.users
       end
@@ -37,30 +67,34 @@ module ForemanResourceQuota
       test 'users relation delete quota' do
         @user.resource_quotas << @quota
         assert_equal @quota.users[0].id, @user.id
-        assert_equal @user.resource_quotas[0].id, @quota.id
+        assert_includes @user.resource_quotas, @unassigned
+        assert_includes @user.resource_quotas, @quota
         @quota.destroy
-        assert_empty @user.reload.resource_quotas
+        assert_not_includes @user.reload.resource_quotas, @quota
       end
 
       test 'usergroups relation' do
         @quota.usergroups << @usergroup
         assert_equal @usergroup.id, @quota.usergroups[0].id
-        assert_equal @quota.id, @usergroup.resource_quotas[0].id
+        assert_includes @usergroup.resource_quotas, @unassigned
+        assert_includes @usergroup.resource_quotas, @quota
       end
 
       test 'usergroup delete' do
         @quota.usergroups << @usergroup
         assert_equal @usergroup.id, @quota.usergroups[0].id
-        assert_equal @quota.id, @usergroup.resource_quotas[0].id
+        assert_includes @usergroup.resource_quotas, @quota
         @usergroup.destroy
         assert_empty @quota.reload.usergroups
       end
 
       test 'number of hosts' do
-        second_host = FactoryBot.create :host
-        third_host = FactoryBot.create :host
-        @quota.hosts << [@host, second_host, third_host]
+        second_host = FactoryBot.create :host, resource_quota: @quota
+        third_host = FactoryBot.create :host, resource_quota: @quota
         assert_equal 3, @quota.number_of_hosts
+        assert_includes @quota.hosts, @host
+        assert_includes @quota.hosts, second_host
+        assert_includes @quota.hosts, third_host
       end
 
       test 'number of users' do
@@ -92,7 +126,6 @@ module ForemanResourceQuota
 
       test 'utilization is set (cpu_cores)' do
         @quota.cpu_cores = 50
-        @quota.hosts << @host
         @quota.update_hosts_resources({ @host.name => { cpu_cores: 13 } })
 
         assert_equal 13, @quota.utilization[:cpu_cores]
@@ -100,7 +133,6 @@ module ForemanResourceQuota
 
       test 'utilization is set (memory_mb)' do
         @quota.memory_mb = 50
-        @quota.hosts << @host
         @quota.update_hosts_resources({ @host.name => { memory_mb: 14 } })
 
         assert_equal 14, @quota.utilization[:memory_mb]
@@ -108,7 +140,6 @@ module ForemanResourceQuota
 
       test 'utilization is set (disk_gb)' do
         @quota.disk_gb = 50
-        @quota.hosts << @host
         @quota.update_hosts_resources({ @host.name => { disk_gb: 15 } })
 
         assert_equal 15, @quota.utilization[:disk_gb]
@@ -117,7 +148,6 @@ module ForemanResourceQuota
       test 'utilization is set (all parameters)' do
         exp_utilization = { cpu_cores: 3, memory_mb: 4, disk_gb: 5 }
         @quota.update(cpu_cores: 50, memory_mb: 50, disk_gb: 50)
-        @quota.hosts << @host
         @quota.update_hosts_resources({ @host.name => exp_utilization })
 
         assert_equal exp_utilization, @quota.utilization
@@ -129,7 +159,6 @@ module ForemanResourceQuota
         host_utilization = {
           @host.name => exp_utilization,
         }
-        @quota.hosts << @host
         @quota.update(cpu_cores: 10, memory_mb: 10, disk_gb: 10)
 
         @quota.stub(:call_utilization_helper, [host_utilization, exp_missing_hosts]) do
@@ -140,8 +169,11 @@ module ForemanResourceQuota
       end
 
       test 'determine utilization stores missing hosts' do
-        host_a = FactoryBot.create :host
-        host_b = FactoryBot.create :host
+        # remove default host from quota
+        @host.resource_quota = @unassigned
+        host_a = FactoryBot.create :host, resource_quota: @quota
+        host_b = FactoryBot.create :host, resource_quota: @quota
+
         exp_utilization = { cpu_cores: 1, memory_mb: 1, disk_gb: 2 }
         host_utilization = {
           host_a.name => { memory_mb: 1, disk_gb: 1 },
@@ -149,7 +181,6 @@ module ForemanResourceQuota
         }
         exp_missing_hosts = { host_a.name => [:cpu_cores], host_b.name => [:memory_mb] }
 
-        @quota.hosts << [host_a, host_b]
         @quota.update(cpu_cores: 10, memory_mb: 10, disk_gb: 10)
 
         @quota.stub(:call_utilization_helper, [host_utilization, exp_missing_hosts]) do
@@ -160,14 +191,15 @@ module ForemanResourceQuota
       end
 
       test 'missing_hosts are destroyed on host destroy' do
-        host_a = FactoryBot.create :host
-        host_b = FactoryBot.create :host
+        # remove default host from quota
+        @host.resource_quota = @unassigned
+        host_a = FactoryBot.create :host, resource_quota: @quota
+        host_b = FactoryBot.create :host, resource_quota: @quota
         host_utilization = {
           host_a.name => { memory_mb: 1, disk_gb: 1 },
           host_b.name => { cpu_cores: 1, disk_gb: 1 },
         }
         exp_missing_hosts = { host_a.name => [:cpu_cores], host_b.name => [:memory_mb] }
-        @quota.hosts << [host_a, host_b]
         @quota.update(cpu_cores: 10, memory_mb: 10, disk_gb: 10)
         @quota.save!
 
@@ -183,9 +215,11 @@ module ForemanResourceQuota
       end
 
       test 'missing_hosts are destroyed on re-computing utilization' do
+        # remove default host from quota
+        @host.resource_quota = @unassigned
         @quota.update(cpu_cores: 10, memory_mb: 10)
-        host_a = FactoryBot.create :host
-        host_b = FactoryBot.create :host
+        host_a = FactoryBot.create :host, resource_quota: @quota
+        host_b = FactoryBot.create :host, resource_quota: @quota
         host_utilization_two = {
           host_a.name => { cpu_cores: 1, memory_mb: nil },
           host_b.name => { cpu_cores: nil, memory_mb: 1 },
@@ -196,8 +230,6 @@ module ForemanResourceQuota
         }
         exp_missing_hosts_two = { host_a.name => [:memory_mb], host_b.name => [:cpu_cores] }
         exp_missing_hosts_one = { host_b.name => [:cpu_cores] }
-
-        @quota.hosts << [host_a, host_b]
 
         @quota.stub(:call_utilization_helper, [host_utilization_two, exp_missing_hosts_two]) do
           @quota.determine_utilization

--- a/webpack/components/ResourceQuotaEmptyState/__test__/__snapshots__/ResourceQuotaEmptyState.test.js.snap
+++ b/webpack/components/ResourceQuotaEmptyState/__test__/__snapshots__/ResourceQuotaEmptyState.test.js.snap
@@ -57,6 +57,7 @@ exports[`ResourceQuotaEmptyState should render 1`] = `
           "disk_gb": null,
           "memory_mb": null,
           "name": "",
+          "unassigned": false,
         }
       }
       initialStatus={
@@ -75,6 +76,7 @@ exports[`ResourceQuotaEmptyState should render 1`] = `
       isNewQuota={true}
       onSubmit={[Function]}
       quotaChangesCallback={null}
+      showAssignmentWarning={false}
     />
   </Modal>
 </div>

--- a/webpack/components/ResourceQuotaForm/ResourceQuotaFormConstants.js
+++ b/webpack/components/ResourceQuotaForm/ResourceQuotaFormConstants.js
@@ -2,6 +2,7 @@
 export const RESOURCE_IDENTIFIER_ID = 'id';
 export const RESOURCE_IDENTIFIER_NAME = 'name';
 export const RESOURCE_IDENTIFIER_DESCRIPTION = 'description';
+export const RESOURCE_IDENTIFIER_UNASSIGNED = 'unassigned';
 export const RESOURCE_IDENTIFIER_CPU = 'cpu_cores';
 export const RESOURCE_IDENTIFIER_MEMORY = 'memory_mb';
 export const RESOURCE_IDENTIFIER_DISK = 'disk_gb';

--- a/webpack/components/ResourceQuotaForm/components/Properties/TextInputField.js
+++ b/webpack/components/ResourceQuotaForm/components/Properties/TextInputField.js
@@ -19,6 +19,7 @@ const TextInputField = ({
   isRequired,
   isTextArea,
   isNewQuota,
+  isDisabled,
 }) => {
   const dispatch = useDispatch();
   const [currentAttribute, setCurrentAttribute] = useState();
@@ -100,7 +101,7 @@ const TextInputField = ({
       loading={isLoading && currentAttribute === attribute}
       onEdit={onEdit}
       value={value}
-      disabled={false}
+      disabled={isDisabled}
       textArea={isTextArea}
       validated={validated}
       {...{ currentAttribute, setCurrentAttribute }}
@@ -114,6 +115,7 @@ TextInputField.defaultProps = {
   isRequired: false,
   isRestrictInputValidation: false,
   isNewQuota: false,
+  isDisabled: false,
 };
 
 TextInputField.propTypes = {
@@ -127,6 +129,7 @@ TextInputField.propTypes = {
   isTextArea: PropTypes.bool,
   isRequired: PropTypes.bool,
   isNewQuota: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 export default TextInputField;

--- a/webpack/components/ResourceQuotaForm/components/Properties/index.js
+++ b/webpack/components/ResourceQuotaForm/components/Properties/index.js
@@ -17,6 +17,7 @@ import {
 } from '@patternfly/react-core';
 
 import {
+  ExclamationCircleIcon,
   UserIcon,
   UsersIcon,
   ClusterIcon,
@@ -42,6 +43,8 @@ const Properties = ({
   initialName,
   initialDescription,
   initialStatus,
+  unassigned,
+  showAssignmentWarning,
   handleInputValidation,
   onChange,
   onApply,
@@ -111,32 +114,48 @@ const Properties = ({
         <FlexItem>
           <LabelGroup isCompact>
             <StatusPropertiesLabel
-              color="blue"
-              iconChild={<ClusterIcon />}
+              color={showAssignmentWarning ? 'red' : 'blue'}
+              iconChild={
+                showAssignmentWarning ? (
+                  <ExclamationCircleIcon />
+                ) : (
+                  <ClusterIcon />
+                )
+              }
               statusContent={
                 statusProperties[RESOURCE_IDENTIFIER_STATUS_NUM_HOSTS]
               }
               linkUrl={`/hosts?search=resource_quota="${initialName}"`}
-              tooltipText="Number of assigned hosts"
-            />
-            <StatusPropertiesLabel
-              color="blue"
-              iconChild={<UserIcon />}
-              statusContent={
-                statusProperties[RESOURCE_IDENTIFIER_STATUS_NUM_USERS]
+              tooltipText={
+                showAssignmentWarning
+                  ? __(
+                      "The setting 'resource_quota_optional_assignment' is set to 'No' but there are hosts with no quota assignment. Please check your hosts' quota assignments!"
+                    )
+                  : __('Number of assigned hosts')
               }
-              linkUrl={`/users?search=resource_quota="${initialName}"`}
-              tooltipText="Number of assigned users"
             />
-            <StatusPropertiesLabel
-              color="blue"
-              iconChild={<UsersIcon />}
-              statusContent={
-                statusProperties[RESOURCE_IDENTIFIER_STATUS_NUM_USERGROUPS]
-              }
-              linkUrl={`/usergroups?search=resource_quota="${initialName}"`}
-              tooltipText="Number of assigned usergroups"
-            />
+            {!unassigned && (
+              <StatusPropertiesLabel
+                color="blue"
+                iconChild={<UserIcon />}
+                statusContent={
+                  statusProperties[RESOURCE_IDENTIFIER_STATUS_NUM_USERS]
+                }
+                linkUrl={`/users?search=resource_quota="${initialName}"`}
+                tooltipText="Number of assigned users"
+              />
+            )}
+            {!unassigned && (
+              <StatusPropertiesLabel
+                color="blue"
+                iconChild={<UsersIcon />}
+                statusContent={
+                  statusProperties[RESOURCE_IDENTIFIER_STATUS_NUM_USERGROUPS]
+                }
+                linkUrl={`/usergroups?search=resource_quota="${initialName}"`}
+                tooltipText="Number of assigned usergroups"
+              />
+            )}
           </LabelGroup>
         </FlexItem>
       </Flex>
@@ -161,6 +180,7 @@ const Properties = ({
               onChange={onChange}
               isRestrictInputValidation
               isRequired
+              isDisabled={unassigned}
             />
             <TextInputField
               initialValue={initialDescription}
@@ -171,6 +191,7 @@ const Properties = ({
               onApply={onApply}
               onChange={onChange}
               isTextArea
+              isDisabled={unassigned}
             />
           </TextList>
         </TextContent>
@@ -187,6 +208,8 @@ Properties.defaultProps = {
     [RESOURCE_IDENTIFIER_STATUS_NUM_USERS]: null,
     [RESOURCE_IDENTIFIER_STATUS_NUM_USERGROUPS]: null,
   },
+  unassigned: false,
+  showAssignmentWarning: false,
 };
 
 Properties.propTypes = {
@@ -198,6 +221,8 @@ Properties.propTypes = {
     [RESOURCE_IDENTIFIER_STATUS_NUM_USERS]: PropTypes.number,
     [RESOURCE_IDENTIFIER_STATUS_NUM_USERGROUPS]: PropTypes.number,
   }),
+  unassigned: PropTypes.bool,
+  showAssignmentWarning: PropTypes.bool,
   handleInputValidation: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onApply: PropTypes.func.isRequired,

--- a/webpack/components/ResourceQuotaForm/index.js
+++ b/webpack/components/ResourceQuotaForm/index.js
@@ -16,6 +16,7 @@ import {
   RESOURCE_IDENTIFIER_CPU,
   RESOURCE_IDENTIFIER_MEMORY,
   RESOURCE_IDENTIFIER_DISK,
+  RESOURCE_IDENTIFIER_UNASSIGNED,
   RESOURCE_IDENTIFIER_STATUS_NUM_HOSTS,
   RESOURCE_IDENTIFIER_STATUS_NUM_USERS,
   RESOURCE_IDENTIFIER_STATUS_NUM_USERGROUPS,
@@ -25,6 +26,7 @@ import {
 
 const ResourceQuotaForm = ({
   isNewQuota,
+  showAssignmentWarning,
   initialProperties,
   initialStatus,
   onSubmit,
@@ -72,6 +74,10 @@ const ResourceQuotaForm = ({
                   RESOURCE_IDENTIFIER_DESCRIPTION
                 )}
                 initialStatus={modelState.getQuotaStatus()}
+                unassigned={modelState.getQuotaProperties(
+                  RESOURCE_IDENTIFIER_UNASSIGNED
+                )}
+                showAssignmentWarning={showAssignmentWarning}
                 handleInputValidation={modelState.handleInputValidation}
                 onChange={modelState.onChange}
                 onApply={modelState.onApply}
@@ -80,25 +86,29 @@ const ResourceQuotaForm = ({
             )}
           </SkeletonLoader>
         </GalleryItem>
-        <GalleryItem key="edit-resource-quota-resources-item">
-          <SkeletonLoader
-            skeletonProps={{ width: 400 }}
-            status={isNewQuota || !isLoading ? STATUS.RESOLVED : STATUS.PENDING}
-          >
-            {(!isLoading || isNewQuota) && (
-              <Resources
-                isNewQuota={isNewQuota}
-                initialProperties={modelState.getQuotaProperties()}
-                initialStatus={modelState.getQuotaStatus(
-                  RESOURCE_IDENTIFIER_STATUS_UTILIZATION
-                )}
-                handleInputValidation={modelState.handleInputValidation}
-                onChange={modelState.onChange}
-                onApply={modelState.onApply}
-              />
-            )}
-          </SkeletonLoader>
-        </GalleryItem>
+        {!modelState.getQuotaProperties(RESOURCE_IDENTIFIER_UNASSIGNED) && (
+          <GalleryItem key="edit-resource-quota-resources-item">
+            <SkeletonLoader
+              skeletonProps={{ width: 400 }}
+              status={
+                isNewQuota || !isLoading ? STATUS.RESOLVED : STATUS.PENDING
+              }
+            >
+              {(!isLoading || isNewQuota) && (
+                <Resources
+                  isNewQuota={isNewQuota}
+                  initialProperties={modelState.getQuotaProperties()}
+                  initialStatus={modelState.getQuotaStatus(
+                    RESOURCE_IDENTIFIER_STATUS_UTILIZATION
+                  )}
+                  handleInputValidation={modelState.handleInputValidation}
+                  onChange={modelState.onChange}
+                  onApply={modelState.onApply}
+                />
+              )}
+            </SkeletonLoader>
+          </GalleryItem>
+        )}
         {isNewQuota && (
           <GalleryItem key="edit-resource-quota-submit-item">
             <Submit
@@ -114,6 +124,7 @@ const ResourceQuotaForm = ({
 };
 
 ResourceQuotaForm.defaultProps = {
+  showAssignmentWarning: false,
   onSubmit: null,
   quotaChangesCallback: null,
   initialProperties: {
@@ -122,6 +133,7 @@ ResourceQuotaForm.defaultProps = {
     [RESOURCE_IDENTIFIER_CPU]: null,
     [RESOURCE_IDENTIFIER_MEMORY]: null,
     [RESOURCE_IDENTIFIER_DISK]: null,
+    [RESOURCE_IDENTIFIER_UNASSIGNED]: false,
   },
   initialStatus: {
     [RESOURCE_IDENTIFIER_STATUS_NUM_HOSTS]: null,
@@ -138,6 +150,7 @@ ResourceQuotaForm.defaultProps = {
 
 ResourceQuotaForm.propTypes = {
   isNewQuota: PropTypes.bool.isRequired,
+  showAssignmentWarning: PropTypes.bool,
   onSubmit: PropTypes.func,
   quotaChangesCallback: PropTypes.func,
   initialProperties: PropTypes.shape({
@@ -147,6 +160,7 @@ ResourceQuotaForm.propTypes = {
     [RESOURCE_IDENTIFIER_CPU]: PropTypes.number,
     [RESOURCE_IDENTIFIER_MEMORY]: PropTypes.number,
     [RESOURCE_IDENTIFIER_DISK]: PropTypes.number,
+    [RESOURCE_IDENTIFIER_UNASSIGNED]: PropTypes.bool,
   }),
   initialStatus: PropTypes.shape({
     [RESOURCE_IDENTIFIER_STATUS_NUM_HOSTS]: PropTypes.oneOfType([

--- a/webpack/components/UpdateResourceQuotaModal.js
+++ b/webpack/components/UpdateResourceQuotaModal.js
@@ -20,7 +20,11 @@ import {
   RESOURCE_IDENTIFIER_STATUS_UTILIZATION,
 } from './ResourceQuotaForm/ResourceQuotaFormConstants';
 
-const UpdateResourceQuotaModal = ({ initialProperties, initialStatus }) => {
+const UpdateResourceQuotaModal = ({
+  initialProperties,
+  initialStatus,
+  showAssignmentWarning,
+}) => {
   const staticId = `${MODAL_ID_UPDATE_RESOURCE_QUOTA}-${initialProperties[RESOURCE_IDENTIFIER_ID]}`;
   const [isOpen, setIsOpen] = useState(false);
   const [quotaProperties, setQuotaProperties] = useState(initialProperties);
@@ -52,6 +56,7 @@ const UpdateResourceQuotaModal = ({ initialProperties, initialStatus }) => {
       >
         <ResourceQuotaForm
           isNewQuota={false}
+          showAssignmentWarning={showAssignmentWarning}
           initialProperties={quotaProperties}
           initialStatus={quotaStatus}
           quotaChangesCallback={onQuotaChangesCallback}
@@ -138,6 +143,7 @@ UpdateResourceQuotaModal.propTypes = {
       ]),
     }),
   }),
+  showAssignmentWarning: PropTypes.bool.isRequired,
 };
 
 export default UpdateResourceQuotaModal;


### PR DESCRIPTION
This is needed for #135 

The initial implementation works without the need to set a quota - there is a setting 'resource_quota_optional_assignment' which can be set to true such that setting the quota becomes optional when creating a host. This is to leverage possible negative user experience when a quota is exceeded, especially at an early stage of plugin development.

In the initial design, for host registration the check implementation does not work for mandatory assignment of a quota. In general, it is possible to have no resource quota assigned, hence the quota can be set to 'nil'. This works well for the optional assignment in general and also host deployment via orcharhino with mandatory assignment. However, host registration with mandatory assignment fails. This is because there is a check when saving a host that fires when a resource quota should be set but is not. There are two problems:

1) At the moment, there is no possibility to set the resource quota during host registration, so this check always fails.

2) Even when the quota is set, there is a host creation process in Katello in such an early stage that no quota is set at that point and the check still fails even if a quota is provided because the quota check fires on host.save! .

This PR alleviates the problem during host registration by introducing a new quota 'Unassigned' which is set at host creation when no quota is assigned. However, this requires a significant redesign of the underlying plugin structure.