### PR TITLE
Move resource quota field on hosts edit page

### DIFF
--- a/lib/foreman_resource_quota/register.rb
+++ b/lib/foreman_resource_quota/register.rb
@@ -85,7 +85,8 @@ Foreman::Plugin.register :foreman_resource_quota do
     cx.add_pagelet :main_tab_fields,
       id: :quota_hosts_tab_fields,
       resource_type: :host,
-      partial: 'hosts/form_quota_fields'
+      partial: 'hosts/form_quota_fields',
+      priority: 90
   end
 
   # Add global Foreman settings


### PR DESCRIPTION
Currently, it divides the Puppet related fields on the host edit page. This is due to the Puppet fields being split up between Foreman core and the foreman_puppet plugin. The certificate fields are still managed in core while the environment field is now part of foreman_puppet. This change moves the field up such that the Puppet fields will be in one block.

Before:
<img width="196" height="319" alt="image" src="https://github.com/user-attachments/assets/e7d11915-5019-4780-a8e4-a1910fedb2f6" />



After:
<img width="203" height="344" alt="image" src="https://github.com/user-attachments/assets/7d665c76-a116-4b8b-9f77-be65ef299e3b" />

