### PR TITLE
Relax foreman-tasks dependency upper bound to < 14

### DIFF
--- a/foreman_resource_quota.gemspec
+++ b/foreman_resource_quota.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
 
-  s.add_dependency 'foreman-tasks', '>= 10.0', '< 13'
+  s.add_dependency 'foreman-tasks', '>= 10.0', '< 14'
 
   s.add_development_dependency 'theforeman-rubocop', '~> 0.1.2'
 end


### PR DESCRIPTION
foreman-tasks 13.0.0 has been released. The current upper bound of `< 13` causes repoclosure failures for packages depending on this gem when built against repositories containing foreman-tasks 13.x.

This relaxes the constraint to `< 14` to restore compatibility.

See: https://github.com/theforeman/foreman-packaging/pull/13661